### PR TITLE
GAD-5: https://rajkamalsir1978.atlassian.net/browse/GAD-5

### DIFF
--- a/test-django-project/myapp/views.py
+++ b/test-django-project/myapp/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
 
 def index(request):
-    print("GAD-4")
+    print("GAD-5")
     return render(request, 'index.html', {'message': 'Hello from AWS Lambda!'})


### PR DESCRIPTION
Tooltips in onboarding steps are rendering off-screen or clipped when viewed in Safari browser.

Fix:
Replaced absolute positioning with Popper.js or native position: fixed

Ref - 
[Bug: Tooltip misalignment on Safari](https://rajkamalsir1978.atlassian.net/wiki/spaces/Temp/pages/4063315/Bug+Tooltip+misalignment+on+Safari)