### PR TITLE
GAD-11: https://rajkamalsir1978.atlassian.net/browse/GAD-11

### DIFF
--- a/test-django-project/myapp/views.py
+++ b/test-django-project/myapp/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
 
 def index(request):
-    print("GAD-5")
+    print("GAD-11")
     return render(request, 'index.html', {'message': 'Hello from AWS Lambda!'})


### PR DESCRIPTION
The user metrics widgets overlap or break layout on screens < 768px.

Affects Safari mobile + older Chrome versions

Likely caused by CSS grid fallback

Implemented flexbox fallback as solution

GAD-11: https://rajkamalsir1978.atlassian.net/browse/GAD-11

Ref -
[Bug: Widget Overlap on Small Screens (Web)](https://rajkamalsir1978.atlassian.net/wiki/spaces/Temp/pages/4063379/Bug+Widget+Overlap+on+Small+Screens+Web)